### PR TITLE
frontend-candb PoC

### DIFF
--- a/src/frontend/src/lib/candb_file_upload_declarations/candb_file_upload.did
+++ b/src/frontend/src/lib/candb_file_upload_declarations/candb_file_upload.did
@@ -1,0 +1,133 @@
+type Tree = 
+ variant {
+   leaf;
+   node:
+    record {
+      Color;
+      Tree;
+      record {
+        text;
+        opt AttributeValueRBTreeValue;
+      };
+      Tree;
+    };
+ };
+type ScanOptions = 
+ record {
+   ascending: opt bool;
+   limit: nat;
+   pk: PK;
+   skLowerBound: SK;
+   skUpperBound: SK;
+ };
+type SK = text;
+type RemoveOptions = 
+ record {
+   pk: PK;
+   sk: SK;
+ };
+type PropertyShared = 
+ record {
+   immutable: bool;
+   name: text;
+   value: CandyShared;
+ };
+type PK = text;
+type File = 
+ record {
+   content: blob;
+   name: text;
+ };
+type Color = 
+ variant {
+   B;
+   R;
+ };
+type CandyShared = 
+ variant {
+   Array: vec CandyShared;
+   Blob: blob;
+   Bool: bool;
+   Bytes: vec nat8;
+   Class: vec PropertyShared;
+   Float: float64;
+   Floats: vec float64;
+   Int: int;
+   Int16: int16;
+   Int32: int32;
+   Int64: int64;
+   Int8: int8;
+   Ints: vec int;
+   Map: vec record {
+              text;
+              CandyShared;
+            };
+   Nat: nat;
+   Nat16: nat16;
+   Nat32: nat32;
+   Nat64: nat64;
+   Nat8: nat8;
+   Nats: vec nat;
+   Option: opt CandyShared;
+   Principal: principal;
+   Set: vec CandyShared;
+   Text: text;
+   ValueMap: vec record {
+                   CandyShared;
+                   CandyShared;
+                 };
+ };
+type AttributeValueRBTreeValue = 
+ variant {
+   arrayBool: vec bool;
+   arrayFloat: vec float64;
+   arrayInt: vec int;
+   arrayText: vec text;
+   "blob": blob;
+   "bool": bool;
+   candy: CandyShared;
+   float: float64;
+   "int": int;
+   "text": text;
+   tuple: vec AttributeValuePrimitive;
+ };
+type AttributeValuePrimitive = 
+ variant {
+   "bool": bool;
+   float: float64;
+   "int": int;
+   "text": text;
+ };
+type AttributeValue = 
+ variant {
+   arrayBool: vec bool;
+   arrayFloat: vec float64;
+   arrayInt: vec int;
+   arrayText: vec text;
+   "blob": blob;
+   "bool": bool;
+   candy: CandyShared;
+   float: float64;
+   "int": int;
+   "text": text;
+   tree: Tree;
+   tuple: vec AttributeValuePrimitive;
+ };
+type AttributeKey = text;
+service : {
+  create: (File) -> ();
+  download_wrapper: (text) -> (blob);
+  get: (text) -> (opt File) query;
+  remove: (RemoveOptions) -> (opt File);
+  scan: (ScanOptions) -> (vec opt File) query;
+  update:
+   (record {
+      attributesToUpdate: vec record {
+                                AttributeKey;
+                                AttributeValue;
+                              };
+      pk: PK;
+      sk: SK;
+    }) -> (opt File);
+  upload_wrapper: (text, blob) -> ();
+}

--- a/src/frontend/src/lib/candb_file_upload_declarations/candb_file_upload.did.d.ts
+++ b/src/frontend/src/lib/candb_file_upload_declarations/candb_file_upload.did.d.ts
@@ -1,0 +1,94 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+
+export type AttributeKey = string;
+export type AttributeValue = { 'int' : bigint } |
+  { 'float' : number } |
+  { 'tuple' : Array<AttributeValuePrimitive> } |
+  { 'blob' : Uint8Array | number[] } |
+  { 'bool' : boolean } |
+  { 'candy' : CandyShared } |
+  { 'text' : string } |
+  { 'tree' : Tree } |
+  { 'arrayBool' : Array<boolean> } |
+  { 'arrayText' : Array<string> } |
+  { 'arrayInt' : Array<bigint> } |
+  { 'arrayFloat' : Array<number> };
+export type AttributeValuePrimitive = { 'int' : bigint } |
+  { 'float' : number } |
+  { 'bool' : boolean } |
+  { 'text' : string };
+export type AttributeValueRBTreeValue = { 'int' : bigint } |
+  { 'float' : number } |
+  { 'tuple' : Array<AttributeValuePrimitive> } |
+  { 'blob' : Uint8Array | number[] } |
+  { 'bool' : boolean } |
+  { 'candy' : CandyShared } |
+  { 'text' : string } |
+  { 'arrayBool' : Array<boolean> } |
+  { 'arrayText' : Array<string> } |
+  { 'arrayInt' : Array<bigint> } |
+  { 'arrayFloat' : Array<number> };
+export type CandyShared = { 'Int' : bigint } |
+  { 'Map' : Array<[string, CandyShared]> } |
+  { 'Nat' : bigint } |
+  { 'Set' : Array<CandyShared> } |
+  { 'Nat16' : number } |
+  { 'Nat32' : number } |
+  { 'Nat64' : bigint } |
+  { 'Blob' : Uint8Array | number[] } |
+  { 'Bool' : boolean } |
+  { 'Int8' : number } |
+  { 'Ints' : Array<bigint> } |
+  { 'Nat8' : number } |
+  { 'Nats' : Array<bigint> } |
+  { 'Text' : string } |
+  { 'Bytes' : Uint8Array | number[] } |
+  { 'Int16' : number } |
+  { 'Int32' : number } |
+  { 'Int64' : bigint } |
+  { 'Option' : [] | [CandyShared] } |
+  { 'Floats' : Array<number> } |
+  { 'Float' : number } |
+  { 'Principal' : Principal } |
+  { 'Array' : Array<CandyShared> } |
+  { 'ValueMap' : Array<[CandyShared, CandyShared]> } |
+  { 'Class' : Array<PropertyShared> };
+export type Color = { 'B' : null } |
+  { 'R' : null };
+export interface File { 'content' : Uint8Array | number[], 'name' : string }
+export type PK = string;
+export interface PropertyShared {
+  'value' : CandyShared,
+  'name' : string,
+  'immutable' : boolean,
+}
+export interface RemoveOptions { 'pk' : PK, 'sk' : SK }
+export type SK = string;
+export interface ScanOptions {
+  'pk' : PK,
+  'limit' : bigint,
+  'ascending' : [] | [boolean],
+  'skLowerBound' : SK,
+  'skUpperBound' : SK,
+}
+export type Tree = { 'leaf' : null } |
+  { 'node' : [Color, Tree, [string, [] | [AttributeValueRBTreeValue]], Tree] };
+export interface _SERVICE {
+  'create' : ActorMethod<[File], undefined>,
+  'download_wrapper' : ActorMethod<[string], Uint8Array | number[]>,
+  'get' : ActorMethod<[string], [] | [File]>,
+  'remove' : ActorMethod<[RemoveOptions], [] | [File]>,
+  'scan' : ActorMethod<[ScanOptions], Array<[] | [File]>>,
+  'update' : ActorMethod<
+    [
+      {
+        'pk' : PK,
+        'sk' : SK,
+        'attributesToUpdate' : Array<[AttributeKey, AttributeValue]>,
+      },
+    ],
+    [] | [File]
+  >,
+  'upload_wrapper' : ActorMethod<[string, Uint8Array | number[]], undefined>,
+}

--- a/src/frontend/src/lib/candb_file_upload_declarations/candb_file_upload.did.js
+++ b/src/frontend/src/lib/candb_file_upload_declarations/candb_file_upload.did.js
@@ -1,0 +1,117 @@
+export const idlFactory = ({ IDL }) => {
+  const CandyShared = IDL.Rec();
+  const Tree = IDL.Rec();
+  const File = IDL.Record({ 'content' : IDL.Vec(IDL.Nat8), 'name' : IDL.Text });
+  const PK = IDL.Text;
+  const SK = IDL.Text;
+  const RemoveOptions = IDL.Record({ 'pk' : PK, 'sk' : SK });
+  const ScanOptions = IDL.Record({
+    'pk' : PK,
+    'limit' : IDL.Nat,
+    'ascending' : IDL.Opt(IDL.Bool),
+    'skLowerBound' : SK,
+    'skUpperBound' : SK,
+  });
+  const AttributeKey = IDL.Text;
+  const AttributeValuePrimitive = IDL.Variant({
+    'int' : IDL.Int,
+    'float' : IDL.Float64,
+    'bool' : IDL.Bool,
+    'text' : IDL.Text,
+  });
+  const PropertyShared = IDL.Record({
+    'value' : CandyShared,
+    'name' : IDL.Text,
+    'immutable' : IDL.Bool,
+  });
+  CandyShared.fill(
+    IDL.Variant({
+      'Int' : IDL.Int,
+      'Map' : IDL.Vec(IDL.Tuple(IDL.Text, CandyShared)),
+      'Nat' : IDL.Nat,
+      'Set' : IDL.Vec(CandyShared),
+      'Nat16' : IDL.Nat16,
+      'Nat32' : IDL.Nat32,
+      'Nat64' : IDL.Nat64,
+      'Blob' : IDL.Vec(IDL.Nat8),
+      'Bool' : IDL.Bool,
+      'Int8' : IDL.Int8,
+      'Ints' : IDL.Vec(IDL.Int),
+      'Nat8' : IDL.Nat8,
+      'Nats' : IDL.Vec(IDL.Nat),
+      'Text' : IDL.Text,
+      'Bytes' : IDL.Vec(IDL.Nat8),
+      'Int16' : IDL.Int16,
+      'Int32' : IDL.Int32,
+      'Int64' : IDL.Int64,
+      'Option' : IDL.Opt(CandyShared),
+      'Floats' : IDL.Vec(IDL.Float64),
+      'Float' : IDL.Float64,
+      'Principal' : IDL.Principal,
+      'Array' : IDL.Vec(CandyShared),
+      'ValueMap' : IDL.Vec(IDL.Tuple(CandyShared, CandyShared)),
+      'Class' : IDL.Vec(PropertyShared),
+    })
+  );
+  const Color = IDL.Variant({ 'B' : IDL.Null, 'R' : IDL.Null });
+  const AttributeValueRBTreeValue = IDL.Variant({
+    'int' : IDL.Int,
+    'float' : IDL.Float64,
+    'tuple' : IDL.Vec(AttributeValuePrimitive),
+    'blob' : IDL.Vec(IDL.Nat8),
+    'bool' : IDL.Bool,
+    'candy' : CandyShared,
+    'text' : IDL.Text,
+    'arrayBool' : IDL.Vec(IDL.Bool),
+    'arrayText' : IDL.Vec(IDL.Text),
+    'arrayInt' : IDL.Vec(IDL.Int),
+    'arrayFloat' : IDL.Vec(IDL.Float64),
+  });
+  Tree.fill(
+    IDL.Variant({
+      'leaf' : IDL.Null,
+      'node' : IDL.Tuple(
+        Color,
+        Tree,
+        IDL.Tuple(IDL.Text, IDL.Opt(AttributeValueRBTreeValue)),
+        Tree,
+      ),
+    })
+  );
+  const AttributeValue = IDL.Variant({
+    'int' : IDL.Int,
+    'float' : IDL.Float64,
+    'tuple' : IDL.Vec(AttributeValuePrimitive),
+    'blob' : IDL.Vec(IDL.Nat8),
+    'bool' : IDL.Bool,
+    'candy' : CandyShared,
+    'text' : IDL.Text,
+    'tree' : Tree,
+    'arrayBool' : IDL.Vec(IDL.Bool),
+    'arrayText' : IDL.Vec(IDL.Text),
+    'arrayInt' : IDL.Vec(IDL.Int),
+    'arrayFloat' : IDL.Vec(IDL.Float64),
+  });
+  return IDL.Service({
+    'create' : IDL.Func([File], [], []),
+    'download_wrapper' : IDL.Func([IDL.Text], [IDL.Vec(IDL.Nat8)], []),
+    'get' : IDL.Func([IDL.Text], [IDL.Opt(File)], ['query']),
+    'remove' : IDL.Func([RemoveOptions], [IDL.Opt(File)], []),
+    'scan' : IDL.Func([ScanOptions], [IDL.Vec(IDL.Opt(File))], ['query']),
+    'update' : IDL.Func(
+        [
+          IDL.Record({
+            'pk' : PK,
+            'sk' : SK,
+            'attributesToUpdate' : IDL.Vec(
+              IDL.Tuple(AttributeKey, AttributeValue)
+            ),
+          }),
+        ],
+        [IDL.Opt(File)],
+        [],
+      ),
+    'upload_wrapper' : IDL.Func([IDL.Text, IDL.Vec(IDL.Nat8)], [], []),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/src/frontend/src/lib/candb_file_upload_declarations/index.d.ts
+++ b/src/frontend/src/lib/candb_file_upload_declarations/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './candb_file_upload.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const candb_file_upload: ActorSubclass<_SERVICE>;

--- a/src/frontend/src/lib/candb_file_upload_declarations/index.js
+++ b/src/frontend/src/lib/candb_file_upload_declarations/index.js
@@ -1,0 +1,43 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from "./candb_file_upload.did.js";
+export { idlFactory } from "./candb_file_upload.did.js";
+
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_CANDB_FILE_UPLOAD ||
+  process.env.CANDB_FILE_UPLOAD_CANISTER_ID;
+
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentOptions) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
+
+  // Fetch root key for certificate validation during development
+  if (process.env.DFX_NETWORK !== "ic") {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options.actorOptions,
+  });
+};
+
+export const candb_file_upload = createActor(canisterId);


### PR DESCRIPTION
In PR #16, we have introduced initial support for CanDB file storage. To demonstrate its proper usage, we have developed a PoC that interacts with CanDB on front-end side.

Please note that this should not be merged, as it is intended solely for demonstration purposes. It aims to assist other developers in integrating front-end with CanDB more efficiently.

Usage:
- Navigate to the `Profile` settings section, where you can click the `Upload Image` button. This action opens a dialog that enables you to upload an image file.
- Within this dialog, click on the `Choose file` option to select your desired JPEG image.
- Once selected, press the `Upload` button to initiate the image upload process.
- To download the image from CanDB, simply click on the `Download` button.

Images:
- <img width="772" alt="Screenshot 2023-12-30 at 14 07 58" src="https://github.com/lukasvozda/nostric/assets/2663035/ba430e86-cede-43e3-878c-bed8e0b53b80">
- <img width="588" alt="Screenshot 2023-12-30 at 14 08 13" src="https://github.com/lukasvozda/nostric/assets/2663035/24bf3cf1-21b2-44a1-af0a-ec14a5714368">
