### PR TITLE
Adding dependabot.yml dependency updater

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- Dependabot is tool which is used to keep our dependencies up-to-date
- it checks every week if updates of dependencies are present and rises PR with bumped dependencies
- PR checks or integration test should fail if there is breaking change preventing compiling, if the version bump is small we are quite safe to merge this automatic PR after checking if the app still works
- It should prevent us having big tech debt