### PR TITLE
Running dfx generate before deployment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -54,5 +54,6 @@ jobs:
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic
+          dfx generate
           dfx deploy --network ic
         continue-on-error: false

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -59,5 +59,6 @@ jobs:
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic
+          dfx generate
           dfx deploy --network ic
         continue-on-error: false


### PR DESCRIPTION
- when we are running build with remote dependency of internet-computer the did file is ignored and frontend is not built
- so we had to add `dfx generate` to make sure production has all necessary dependencies before PROD build starts