### PR TITLE
Adding support for remote candid file

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -54,6 +54,5 @@ jobs:
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic
-          dfx generate
           dfx deploy --network ic
         continue-on-error: false

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -59,6 +59,5 @@ jobs:
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic
-          dfx generate
           dfx deploy --network ic
         continue-on-error: false

--- a/dfx.json
+++ b/dfx.json
@@ -29,7 +29,8 @@
       "remote": {
         "id": {
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
-        }
+        },
+        "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did"
       }
     }
   },


### PR DESCRIPTION
Remote build didn't have .did file location specified. In that case the internet-identity .did generation fails.