### PR TITLE
Adding local build of internet identity to have the .did file available

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -54,5 +54,6 @@ jobs:
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic
+          dfx build internet_identity
           dfx deploy --network ic
         continue-on-error: false

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -59,5 +59,6 @@ jobs:
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic
+          dfx build internet_identity
           dfx deploy --network ic
         continue-on-error: false

--- a/dfx.json
+++ b/dfx.json
@@ -29,8 +29,7 @@
       "remote": {
         "id": {
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
-        },
-        "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did"
+        }
       }
     }
   },


### PR DESCRIPTION
- When building production version of frontend we don't have .did file downloaded since remote containers does not download .did file even when they should
- adding local build of `internet_identity` to have did file available for frontend build in later steps