### PR TITLE
Adding support for generating HTTPS Nostric image urls

### DIFF
--- a/src/frontend/src/lib/identity/IdentityHandler.ts
+++ b/src/frontend/src/lib/identity/IdentityHandler.ts
@@ -149,7 +149,7 @@ export class IdentityHandler {
   }
 
   public async deleteFile(url: string): Promise<void> {
-    let fileName = new URL(url).pathname.split("/").at(-1);
+    const fileName = new URL(url).pathname.split("/").at(-1);
     const result: Result = await this.storageActor.delete(fileName);
     if (result !== undefined && "err" in result) {
       throw Error("Unable to delete file");

--- a/src/frontend/src/lib/identity/IdentityHandler.ts
+++ b/src/frontend/src/lib/identity/IdentityHandler.ts
@@ -149,7 +149,8 @@ export class IdentityHandler {
   }
 
   public async deleteFile(url: string): Promise<void> {
-    const result: Result = await this.storageActor.delete(url);
+    let fileName = new URL(url).pathname.split("/").at(-1);
+    const result: Result = await this.storageActor.delete(fileName);
     if (result !== undefined && "err" in result) {
       throw Error("Unable to delete file");
     } else {

--- a/src/frontend/src/lib/stores/Files.ts
+++ b/src/frontend/src/lib/stores/Files.ts
@@ -5,9 +5,20 @@ function getFiles() {
   const { subscribe, update, set } = files;
 
   const filePathToUrl = (path: string, host: string): string => {
-    return process.env.DFX_NETWORK === "ic"
-      ? `https://${process.env.STORAGE_CANISTER_ID}.raw.icp0.io/${path}`
-      : `${host}/?canisterId=${process.env.STORAGE_CANISTER_ID}${path}`;
+    let url;
+    if (process.env.DFX_NETWORK === "ic") {
+      let hostname = location.hostname;
+      if (hostname.includes("dev.nostric.app")) {
+        url = `https://img.dev.nostric.app/${path}`;
+      } else if (hostname.includes("nostric.app")) {
+        url = `https://img.nostric.app/${path}`;
+      } else {
+        url = `https://${process.env.STORAGE_CANISTER_ID}.raw.icp0.io/${path}`;
+      }
+    } else {
+      url = `${host}/?canisterId=${process.env.STORAGE_CANISTER_ID}${path}`;
+    }
+    return url;
   };
 
   const fill = (urls: string[], host?: string): void => {

--- a/src/frontend/src/lib/stores/Files.ts
+++ b/src/frontend/src/lib/stores/Files.ts
@@ -7,7 +7,7 @@ function getFiles() {
   const filePathToUrl = (path: string, host: string): string => {
     let url;
     if (process.env.DFX_NETWORK === "ic") {
-      let hostname = location.hostname;
+      const hostname = location.hostname;
       if (hostname.includes("dev.nostric.app")) {
         url = `https://img.dev.nostric.app/${path}`;
       } else if (hostname.includes("nostric.app")) {


### PR DESCRIPTION
- generating urls pointing to img.nostric.app / img.dev.nostric.app since we are now hosting storage canister as https custom url
- fixed file deletion (we were sending whole URL address instead of fileName to storage canister)
- NOTE: images which were uploaded before we've added HTTPs support are served only via HTTP (so they won't display content but you can delete them)
  - ![image](https://github.com/nostric-devs/nostric/assets/2663035/30439524-50c4-4e9c-817f-8a4ae7fc0f07)
  - since it's only a few of them we just can ignore them or remove them in UI
  - if it's a problem I can run script on DEV/PROD canisters to add HTTPs support also to old HTTP images
