### PR TITLE
Disable encryption for CI job

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cp canister_ids-dev.json canister_ids.json
           echo "${{ secrets.DFX_IDENTITY_PEM }}" > /home/runner/identity.pem
-          dfx identity import action /home/runner/identity.pem
+          dfx identity import --storage-mode=plaintext --force action /home/runner/identity.pem
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Dev environment deployment
         run: |
           echo "${{ secrets.DFX_IDENTITY_PEM }}" > /home/runner/identity.pem
-          dfx identity import action /home/runner/identity.pem
+          dfx identity import --storage-mode=plaintext --force action /home/runner/identity.pem
           dfx identity use action
           dfx identity set-wallet ${{ secrets.WALLET_CANISTER_ID }} --network ic
           dfx wallet balance --network ic


### PR DESCRIPTION
- Mode 'plaintext' is not safe, but convenient for use in CI [possible values: keyring, password-protected, plaintext]